### PR TITLE
ws.upgradeReq no longer exists

### DIFF
--- a/server.js
+++ b/server.js
@@ -98,9 +98,8 @@ var wss = new ws.Server({
 /*
  * Management of WebSocket messages
  */
-wss.on('connection', function (ws) {
+wss.on('connection', function (ws, request) {
     var sessionId = null;
-    var request = ws.upgradeReq;
     var response = {
         writeHead: {}
     };

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@
  *
  */
 const NodeMediaServer = require('node-media-server').NodeMediaServer;
+
 var path = require('path');
 var url = require('url');
 var cookieParser = require('cookie-parser')
@@ -25,10 +26,7 @@ var ws = require('ws');
 var kurento = require('kurento-client');
 var fs = require('fs');
 var https = require('https');
-var childProcess = require('child_process');
-var spawn = childProcess.spawn;
-var fs = require("fs");
-var path = require('path');
+var spawn = require('child_process').spawn;
 
 var argv = minimist(process.argv.slice(2), {
     default: {


### PR DESCRIPTION
Get it from the connection event instead, based on suggestion here:
https://github.com/websockets/ws/pull/1099

Note that this gets me past an error I was having, but the demo is still not fully working for me, using kurrento running in Docker for mac.